### PR TITLE
Fix touch unresponsive after a cancelled back gesture

### DIFF
--- a/easycrop/src/main/java/com/mr0xf00/easycrop/utils/GestureState.kt
+++ b/easycrop/src/main/java/com/mr0xf00/easycrop/utils/GestureState.kt
@@ -143,8 +143,8 @@ internal fun Modifier.onGestures(state: GestureState): Modifier {
                             event = awaitPointerEvent(pass = PointerEventPass.Initial)
                             var dragPointer: PointerInputChange? = null
                             for (change in event.changes) {
-                                if (change.changedToDown()) info.pointers++
-                                else if (change.changedToUp()) info.pointers--
+                                if (change.changedToDownIgnoreConsumed()) info.pointers++
+                                else if (change.changedToUpIgnoreConsumed()) info.pointers--
                                 info.maxPointers = max(info.maxPointers, info.pointers)
                                 if (change.id == info.dragId) dragPointer = change
                             }


### PR DESCRIPTION
Currently while cropping, if we trigger the back gesture and cancel it, the crop touch becomes unresponsive in some cases and in some cases the behavior becomes odd. I have added a screen recording for the unresponsive case. This change fixes the issue.

https://user-images.githubusercontent.com/8017365/234935535-7fe997d6-6de6-4463-bc35-7df26eac5fd7.mp4

