### PR TITLE
Add a paramter to pass extra padding around crop rect

### DIFF
--- a/easycrop/src/main/java/com/mr0xf00/easycrop/ui/CropperPreview.kt
+++ b/easycrop/src/main/java/com/mr0xf00/easycrop/ui/CropperPreview.kt
@@ -2,6 +2,7 @@ package com.mr0xf00.easycrop.ui
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
@@ -11,7 +12,9 @@ import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.mr0xf00.easycrop.*
 import com.mr0xf00.easycrop.images.rememberLoadedImage
@@ -22,7 +25,8 @@ import kotlinx.coroutines.delay
 @Composable
 fun CropperPreview(
     state: CropState,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    extraPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     val style = LocalCropperStyle.current
     val imgTransform by animateImgTransform(target = state.transform)
@@ -30,7 +34,17 @@ fun CropperPreview(
     val viewMat = remember { ViewMat() }
     var view by remember { mutableStateOf(IntSize.Zero) }
     var pendingDrag by remember { mutableStateOf<DragHandle?>(null) }
-    val viewPadding = LocalDensity.current.run { style.touchRad.toPx() }
+    val layoutDirection = LocalLayoutDirection.current
+    val viewPadding = LocalDensity.current.run {
+        val touchRadPx = style.touchRad.toPx()
+        val maxExtraPadding = maxOf(
+            extraPadding.calculateTopPadding().toPx(),
+            extraPadding.calculateBottomPadding().toPx(),
+            extraPadding.calculateLeftPadding(layoutDirection).toPx(),
+            extraPadding.calculateRightPadding(layoutDirection).toPx(),
+        )
+        maxOf(touchRadPx, maxExtraPadding + touchRadPx / 2)
+    }
     val totalMat = remember(viewMat.matrix, imgMat) { imgMat * viewMat.matrix }
     val image = rememberLoadedImage(state.src, view, totalMat)
     val cropRect = remember(state.region, viewMat.matrix) {

--- a/easycrop/src/main/java/com/mr0xf00/easycrop/ui/ImageCropperDialog.kt
+++ b/easycrop/src/main/java/com/mr0xf00/easycrop/ui/ImageCropperDialog.kt
@@ -39,7 +39,8 @@ fun ImageCropperDialog(
     dialogPadding: PaddingValues = PaddingValues(16.dp),
     dialogShape: Shape = RoundedCornerShape(8.dp),
     topBar: @Composable (CropState) -> Unit = { DefaultTopBar(it) },
-    cropControls: @Composable BoxScope.(CropState) -> Unit = { DefaultControls(it) }
+    cropControls: @Composable BoxScope.(CropState) -> Unit = { DefaultControls(it) },
+    extraPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     CompositionLocalProvider(LocalCropperStyle provides style) {
         Dialog(
@@ -57,7 +58,11 @@ fun ImageCropperDialog(
                             .weight(1f)
                             .clipToBounds()
                     ) {
-                        CropperPreview(state = state, modifier = Modifier.fillMaxSize())
+                        CropperPreview(
+                            state = state,
+                            modifier = Modifier.fillMaxSize(),
+                            extraPadding = extraPadding,
+                        )
                         cropControls(state)
                     }
                 }

--- a/sample/src/main/java/com/mr0xf00/easycrop/MainActivity.kt
+++ b/sample/src/main/java/com/mr0xf00/easycrop/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.core.view.WindowCompat
 import com.mr0xf00.easycrop.presentation.ImagesViewModel
 import com.mr0xf00.easycrop.ui.ViewModelDemo
 import com.mr0xf00.easycrop.ui.theme.EasyCropTheme
@@ -16,6 +17,7 @@ class MainActivity : ComponentActivity() {
     val viewModel: ImagesViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             EasyCropTheme {
                 App(viewModel)
@@ -27,13 +29,12 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun App(viewModel: ImagesViewModel) {
     Surface(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.systemBars),
         color = MaterialTheme.colors.background
     ) {
         ViewModelDemo(viewModel = viewModel, modifier = Modifier.fillMaxSize())
 //        SimpleDemo(modifier = Modifier.fillMaxSize())
     }
 }
-
-
-

--- a/sample/src/main/java/com/mr0xf00/easycrop/ui/DemoContent.kt
+++ b/sample/src/main/java/com/mr0xf00/easycrop/ui/DemoContent.kt
@@ -18,25 +18,35 @@ fun DemoContent(
     selectedImage: ImageBitmap?,
     onPick: () -> Unit,
     modifier: Modifier = Modifier,
+    noDialog: Boolean = false,
 ) {
     if (cropState != null) {
         EasyCropTheme(darkTheme = true) {
-            ImageCropperDialog(state = cropState)
+            if (noDialog) {
+                CropperPreview(
+                    state = cropState,
+                    extraPadding = WindowInsets.mandatorySystemGestures.asPaddingValues(),
+                )
+            } else {
+                ImageCropperDialog(state = cropState)
+            }
         }
     }
     if (cropState == null && loadingStatus != null) {
         LoadingDialog(status = loadingStatus)
     }
-    Column(
-        modifier = modifier.padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        if (selectedImage != null) Image(
-            bitmap = selectedImage, contentDescription = null,
-            modifier = Modifier.weight(1f)
-        ) else Box(contentAlignment = Alignment.Center, modifier = Modifier.weight(1f)) {
-            Text("No image selected !")
+    if (cropState == null) {
+        Column(
+            modifier = modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (selectedImage != null) Image(
+                bitmap = selectedImage, contentDescription = null,
+                modifier = Modifier.weight(1f)
+            ) else Box(contentAlignment = Alignment.Center, modifier = Modifier.weight(1f)) {
+                Text("No image selected !")
+            }
+            Button(onClick = onPick) { Text("Choose Image") }
         }
-        Button(onClick = onPick) { Text("Choose Image") }
     }
 }

--- a/sample/src/main/java/com/mr0xf00/easycrop/ui/ViewModelDemo.kt
+++ b/sample/src/main/java/com/mr0xf00/easycrop/ui/ViewModelDemo.kt
@@ -13,7 +13,8 @@ fun ViewModelDemo(viewModel: ImagesViewModel, modifier: Modifier = Modifier) {
         loadingStatus = viewModel.imageCropper.loadingStatus,
         selectedImage = viewModel.selectedImage.collectAsState().value,
         onPick = { imagePicker.pick() },
-        modifier = modifier
+        modifier = modifier,
+        noDialog = true,
     )
     viewModel.cropError.collectAsState().value?.let { error ->
         CropErrorDialog(error, onDismiss = { viewModel.cropErrorShown() })


### PR DESCRIPTION
When using the CroppingPreview directly, or the cropper dialog with 0 padding, the crop handles overlap the back gestures area. This change allows the user to pass extra padding so that the crop handles do not overlap the gesture area.

I think instead of the library adding the gesture padding internally, it should be up to the user to pass the values.

For the demo to work correctly, I had to set `WindowCompat.setDecorFitsSystemWindows(window, false)` in the `MainActivity`. Otherwise `WindowInsets.mandatorySystemGestures` will always be zero.

Before padding:

https://user-images.githubusercontent.com/8017365/234936914-5892e11c-4912-4049-8e14-435daab513b5.mp4

After padding:

https://user-images.githubusercontent.com/8017365/234936995-de9e9951-3fc4-414c-9ff5-8f9e1e814dd7.mp4

